### PR TITLE
💥 Fix BrokenPipeError when stdout is closed near the end

### DIFF
--- a/mp4parser.py
+++ b/mp4parser.py
@@ -43,6 +43,17 @@ def main():
 	with ps.handle_errors():
 		parse_boxes(ps)
 
+		# Ensure that the stdout flush occurs while inside the handle_errors()
+		# context manager.
+		#
+		# Otherwise, the last few lines of output would be flushed inside the
+		# Python exit handler, leaving any potential BrokenPipeError unhandled
+		# by our code and handled instead by CPython which would print the
+		# following message to stderr to stderr:
+		#
+		# > Exception ignored while flushing sys.stdout:
+		# > BrokenPipeError: [Errno 32] Broken pipe
+		sys.stdout.flush()
 
 # PARSING
 


### PR DESCRIPTION
While we have ps.handle_errors() which will quieten BrokenPipeError, there was still one window of time left unchecked:

Since print() is buffered, it will return immediately for the last few lines and bytes of the output (since flushing will generally only occur once the stdout buffer is full).

main() would finish running, CPython would run the interpreter exit handler, and only once there it would actually try to flush stdout. This could fail with a BrokenPipeError if a piped process downstream closes its stdin, which now CPython would report as an unhandled exception.

This patch fixes the problem by ensuring stdout is flushed before exiting the handle_errors() context manager, so that any BrokenPipeError is handled in our code and no writes to the backing stdout file descriptor occur after main() exits.

> Co-authored-by: Alba Mendez <me@alba.sh>